### PR TITLE
Remove if statement checking for a Hash in a config

### DIFF
--- a/lib/endpoint_base/concerns/param_processor.rb
+++ b/lib/endpoint_base/concerns/param_processor.rb
@@ -45,9 +45,7 @@ module EndpointBase::Concerns
 
     def prepare_config(hsh)
       if hsh.key? 'parameters'
-        if hsh['parameters'].is_a? Hash
-          @config = hsh['parameters']
-        end
+        @config = hsh['parameters']
       end
 
       @config ||= {}


### PR DESCRIPTION
- The `hsh` object passed in responds to `key?` but it's not a Hash. In
Rails, the params are inside an instance of `ActionController::Parameters`